### PR TITLE
Update nodejs to latest v6.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,4 @@
-FROM quay.io/ukhomeofficedigital/nodejs-base:v6.9.1
-
-RUN yum clean all && \
-  yum update -y -q && \
-  yum clean all && \
-  rpm --rebuilddb
+FROM quay.io/ukhomeofficedigital/nodejs-base:v6
 
 COPY package.json /app/package.json
 RUN npm --loglevel warn install --production --no-optional


### PR DESCRIPTION
I updated the nodejs-base to now publish three images on publish:

major
major.minor
and
major.minor.patch

Just following the major version means in the future you don't need to care about updating your base image for security fixes you should just have to rebuild your image.

I did this to stop having to go round and update everything after i release a new base image.