### PR TITLE
Send all AWS responses - especially errors

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,6 @@ pipeline:
     image: node:6
     commands:
       - npm --loglevel warn install
-      - npm run lint
       - npm run test
     when:
       event: [push, pull_request]

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,3 +3,6 @@ extends:
 
 env:
   es6: true
+
+rules:
+  consistent-return: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "6"
+  - "8"
 
 services:
   - docker
@@ -8,7 +9,3 @@ services:
 before_install:
   - docker build --tag travis .
   - docker run -d --net=host -e NODE_ENV=ci travis
-
-script:
-  - npm run lint
-  - npm run test

--- a/controllers/file.js
+++ b/controllers/file.js
@@ -125,7 +125,7 @@ router.post('/', [
   }
 ]);
 
-router.get('/:id', (req, res) => {
+router.get('/:id', (req, res, next) => {
   request.get({
     url: `https://${config.get('aws.bucket')}.s3-${config.get('aws.region')}.amazonaws.com${req.url}`,
     encoding: null,
@@ -133,13 +133,10 @@ router.get('/:id', (req, res) => {
   }, (err, resp, buffer) => {
     if (err) {
       logError(req, err);
+      return next(err);
     }
-    if (resp.statusCode !== 200) {
-      res.status(resp.statusCode).end();
-    } else {
-      res.writeHead(200, resp.headers);
-      res.end(buffer);
-    }
+    res.writeHead(resp.statusCode, resp.headers);
+    res.end(buffer);
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   "description": "Allows POST and GET to a configured s3 bucket.",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint .",
-    "test": "mocha test/",
+    "test": "npm run test:lint && npm run test:unit",
+    "test:lint": "eslint .",
+    "test:unit": "mocha test/",
     "start": "node index"
   },
   "author": "UKHomeOffice",


### PR DESCRIPTION
If a request to AWS fails for some reason we don't get any useful debugging information back in the client. This makes debugging failures near impossible.

Instead allow the full AWS response to be sent for all status codes.