### PR TITLE
Use updated url to access s3 resources

### DIFF
--- a/controllers/file.js
+++ b/controllers/file.js
@@ -127,7 +127,7 @@ router.post('/', [
 
 router.get('/:id', (req, res, next) => {
   request.get({
-    url: `https://${config.get('aws.bucket')}.s3-${config.get('aws.region')}.amazonaws.com${req.url}`,
+    url: `https://${config.get('aws.bucket')}.s3.${config.get('aws.region')}.amazonaws.com${req.url}`,
     encoding: null,
     timeout: config.get('timeout') * 1000
   }, (err, resp, buffer) => {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "UKHomeOffice",
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "^2.7.21",
+    "aws-sdk": "2.167.0",
     "churchill": "^0.3.1",
     "config": "^1.24.0",
     "express": "^4.14.0",


### PR DESCRIPTION
Since aws-sdk@2.150.0 the urls have used a dot-separation between `s3` and `eu-west-1` (or other configured region). Since this is signed into the signature of the url it needs to match that used by the SDK internally.

Fix the version of `aws-sdk` to protect against future changes in AWS url schema.