### PR TITLE
Rewrite file-vault urls to remove AWS args

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,5 +4,8 @@ extends:
 env:
   es6: true
 
+globals:
+  URL: true
+
 rules:
   consistent-return: off

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:8-alpine
 
 RUN apk upgrade --no-cache
 RUN addgroup -S app

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The following environment variables are used to configure file-vault.
   AWS_SIGNATURE_VERSION     | AWS Signature Version (defaults to v4)
   AWS_BUCKET                | AWS Bucket Name
   AWS_EXPIRY_TIME           | Length of time (in seconds) the URL will be valid for (defaults to 1 hour)
+  AWS_PASSWORD              | A password used to encrypt the params that are returned by file-vault
   STORAGE_FILE_DESTINATION  | Temp directory for storing uploaded file (this is deleted on upload or fail and defaults to 'uploads')
   REQUEST_TIMEOUT           | Length of time (in seconds) for timeouts on http requests made by file-vault (when talking to clamAV and s3, defaults to 15s)
   FILE_EXTENSION_WHITELIST  | A comma separated list of file types that you want to white-list (defaults to everything). If the file is not in this list file-vault will respond with an error.

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -10,7 +10,8 @@
     "region": "AWS_REGION",
     "signatureVersion": "AWS_SIGNATURE_VERSION",
     "bucket": "AWS_BUCKET",
-    "expiry": "AWS_EXPIRY_TIME"
+    "expiry": "AWS_EXPIRY_TIME",
+    "password": "PASSWORD"
   },
   "fileDestination": "STORAGE_FILE_DESTINATION",
   "timeout": "REQUEST_TIMEOUT",

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -11,7 +11,7 @@
     "signatureVersion": "AWS_SIGNATURE_VERSION",
     "bucket": "AWS_BUCKET",
     "expiry": "AWS_EXPIRY_TIME",
-    "password": "PASSWORD"
+    "password": "AWS_PASSWORD"
   },
   "fileDestination": "STORAGE_FILE_DESTINATION",
   "timeout": "REQUEST_TIMEOUT",

--- a/config/default.json
+++ b/config/default.json
@@ -11,7 +11,9 @@
     "region": "eu-west-1",
     "signatureVersion": "v4",
     "bucket": "AWS_BUCKET",
-    "expiry": 3600
+    "expiry": 3600,
+    "amzAlgorithm": "AWS4-HMAC-SHA256",
+    "password": "changeme"
   },
   "fileDestination": "uploads",
   "timeout": 15,

--- a/controllers/file.js
+++ b/controllers/file.js
@@ -9,7 +9,7 @@ const fs = require('fs');
 const onFinished = require('on-finished');
 const config = require('config');
 const path = require('path');
-const { URL } = require('url');
+const {URL} = require('url');
 
 const crypto = require('crypto');
 const algorithm = 'aes-256-ctr';

--- a/controllers/file.js
+++ b/controllers/file.js
@@ -15,6 +15,10 @@ const crypto = require('crypto');
 const algorithm = 'aes-256-ctr';
 const password = config.get('aws.password');
 
+if (password === 'changeme') {
+  throw new Error('please set the AWS_PASSWORD');
+}
+
 const upload = multer({
   dest: config.get('fileDestination')
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-vault",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/UKHomeOffice/file-vault"

--- a/test/file.js
+++ b/test/file.js
@@ -69,9 +69,9 @@ describe('/file', () => {
           // set some env vars for the clamav server
           process.env.CLAMAV_REST_URL = 'http://localhost:8080/scan';
           process.env.AWS_BUCKET = 'testbucket';
-          process.env.AWS_ACCESS_KEY_ID = 'test';
-          process.env.AWS_SECRET_ACCESS_KEY = 'test';
-          process.env.AWS_KMS_KEY_ID = 'test';
+          process.env.AWS_ACCESS_KEY_ID = 'test_key_id';
+          process.env.AWS_SECRET_ACCESS_KEY = 'test_secret_key';
+          process.env.AWS_KMS_KEY_ID = 'test_kms_key';
           process.env.AWS_REGION = 'eu-west-1';
           process.env.AWS_SIGNATURE_VERSION = 'v4';
 
@@ -115,9 +115,9 @@ describe('/file', () => {
           // set some env vars for the clamav server
           process.env.CLAMAV_REST_URL = 'http://localhost:8080/scan';
           process.env.AWS_BUCKET = 'testbucket';
-          process.env.AWS_ACCESS_KEY_ID = 'test';
-          process.env.AWS_SECRET_ACCESS_KEY = 'test';
-          process.env.AWS_KMS_KEY_ID = 'test';
+          process.env.AWS_ACCESS_KEY_ID = 'test_key_id';
+          process.env.AWS_SECRET_ACCESS_KEY = 'test_secret_key';
+          process.env.AWS_KMS_KEY_ID = 'test_kms_key';
           process.env.AWS_REGION = 'eu-west-1';
           process.env.AWS_SIGNATURE_VERSION = 'v4';
           process.env.FILE_VAULT_URL = 'https://myfile-vault-url';

--- a/test/file.js
+++ b/test/file.js
@@ -8,7 +8,21 @@ const assert = require('assert');
 
 describe('/file', () => {
 
+  describe('config', () => {
+    it('returns an error if the default password isnt changed', () => {
+      assert.throws(() => require('../controllers/file'), Error, 'please set the AWS_PASSWORD');
+    });
+  });
+
   describe('POSTing', () => {
+    beforeEach(() => {
+      process.env.AWS_PASSWORD = 'atest';
+
+      // delete the require cache
+      delete require.cache[require.resolve('../app')];
+      delete require.cache[require.resolve('config')];
+      delete require.cache[require.resolve('../controllers/file')];
+    });
 
     describe('no data', () => {
       it('returns an error', (done) => {
@@ -37,11 +51,6 @@ describe('/file', () => {
       describe('virus scanning', () => {
 
         it('returns an error when virus scanner finds a virus!', (done) => {
-          // delete the require cache
-          delete require.cache[require.resolve('../app')];
-          delete require.cache[require.resolve('config')];
-          delete require.cache[require.resolve('../controllers/file')];
-
           // set some env vars for the clamav server
           process.env.CLAMAV_REST_URL = 'http://localhost:8080/scan';
 
@@ -61,11 +70,6 @@ describe('/file', () => {
 
       describe('putting the file into a bucket', () => {
         it('returns an error when it fails to put', (done) => {
-          // delete the require cache
-          delete require.cache[require.resolve('../app')];
-          delete require.cache[require.resolve('config')];
-          delete require.cache[require.resolve('../controllers/file')];
-
           // set some env vars for the clamav server
           process.env.CLAMAV_REST_URL = 'http://localhost:8080/scan';
           process.env.AWS_BUCKET = 'testbucket';
@@ -90,11 +94,6 @@ describe('/file', () => {
         });
 
         it('returns an error when file extension is not in white-list', (done) => {
-          // delete the require cache
-          delete require.cache[require.resolve('../app')];
-          delete require.cache[require.resolve('config')];
-          delete require.cache[require.resolve('../controllers/file')];
-
           process.env.FILE_EXTENSION_WHITELIST = 'jpg,jpeg,pdf,svg,txt,doc';
 
           supertest(require('../app').app)
@@ -107,11 +106,6 @@ describe('/file', () => {
         });
 
         it('returns a short url when it successfully puts', (done) => {
-          // delete the require cache
-          delete require.cache[require.resolve('../app')];
-          delete require.cache[require.resolve('config')];
-          delete require.cache[require.resolve('../controllers/file')];
-
           // set some env vars for the clamav server
           process.env.CLAMAV_REST_URL = 'http://localhost:8080/scan';
           process.env.AWS_BUCKET = 'testbucket';


### PR DESCRIPTION
This stops the URL's being returned by file-vault containing the same params as the signedUrl that's returned from AWS.