### PR TITLE
FA-81 and ROTM-20: Added timeout and filesize limits for clamav scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The following environment variables are used to configure file-vault.
   STORAGE_FILE_DESTINATION  | Temp directory for storing uploaded file (this is deleted on upload or fail and defaults to 'uploads')
   REQUEST_TIMEOUT           | Length of time (in seconds) for timeouts on http requests made by file-vault (when talking to clamAV and s3, defaults to 15s)
   FILE_EXTENSION_WHITELIST  | A comma separated list of file types that you want to white-list (defaults to everything). If the file is not in this list file-vault will respond with an error.
+  MAX_FILE_SIZE             | The maximum file size that Clam AV will scan (bytes). Default is 105 mb. 
 ```
 
 ## Tutorial

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -15,5 +15,6 @@
   },
   "fileDestination": "STORAGE_FILE_DESTINATION",
   "timeout": "REQUEST_TIMEOUT",
-  "fileTypes": "FILE_EXTENSION_WHITELIST"
+  "fileTypes": "FILE_EXTENSION_WHITELIST",
+  "fileSize": "MAX_FILE_SIZE"
 }

--- a/config/default.json
+++ b/config/default.json
@@ -16,6 +16,7 @@
     "password": ""
   },
   "fileDestination": "uploads",
-  "timeout": 15,
-  "fileTypes": ""
+  "timeout": "REQUEST_TIMEOUT",
+  "fileTypes": "",
+  "fileSize": "MAX_FILE_SIZE"
 }

--- a/controllers/file.js
+++ b/controllers/file.js
@@ -95,7 +95,8 @@ function clamAV(req, res, next) {
   request.post({
     url: config.get('clamRest.url'),
     formData: fileData,
-    timeout: config.get('timeout') * 1000
+    timeout: parseInt(config.get('timeout')) * 1000,
+    fileSize: parseInt(config.get('fileSize'))
   }, (err, httpResponse, body) => {
     if (err) {
       logError(req, err);


### PR DESCRIPTION
**Changes**	

- Timeout and filesize limits added for clam av scan, to mitigate 502 error message being shown to user instead of file upload validation.
- Added MAX_FILE_SIZE to the readme file