### PR TITLE
HOFF-780 - Implement error handling when Clam Anti Virus service is not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 uploads
 .idea
+.env

--- a/controllers/file.js
+++ b/controllers/file.js
@@ -102,7 +102,13 @@ function clamAV(req, res, next) {
       err = {
         code: 'VirusScanFailed'
       };
-    } else if (body.indexOf('false') !== -1) {
+    }
+    else if (httpResponse && httpResponse.statusCode >= 400 ){
+      err = {
+        code: 'VirusScanFailed'
+      };
+    }
+    else if (body.indexOf('false') !== -1) {
       err = {
         code: 'VirusFound'
       };


### PR DESCRIPTION
**What**
Implement error handling for HTTP response codes in the 4xx and 5xx range returned from the ClamAV REST service. [HOFF-780](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-780)

**Why**
HTTP response codes in the 4xx and 5xx range from the  ClamAV REST service are not checked, which poses a security risk, as files that have not been properly scanned due to misconfiguration or downtime of the ClamAV service could be falsely marked as safe and uploaded to the storage, potentially allowing malicious files to bypass our security measures.

**How**
Check for http response status codes that are greater than or equal to 400 and raise an error.

**Test**
Testing in branch and UAT