### PR TITLE
automating pushing of tags

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ steps:
   - yarn install --frozen-lockfile
   when:
     branch: master
-    event: [ push, pull_request ]
+    event: [ push, pull_request, tag ]
 
 - name: build_file-vault
   pull: if-not-exists
@@ -21,7 +21,7 @@ steps:
   - docker build -t file-vault-$${DRONE_COMMIT_SHA} .
   when:
     branch: master
-    event: [ push, pull_request ]
+    event: [ push, pull_request, tag ]
 
 - name: image_to_quay
   pull: if-not-exists
@@ -36,7 +36,7 @@ steps:
   - docker push quay.io/ukhomeofficedigital/file-vault:$${DRONE_COMMIT_SHA}
   when:
     branch: master
-    event: [ push, pull_request ]
+    event: [ push, pull_request, tag ]
 
 services:
   - name: docker


### PR DESCRIPTION
## What? 

* Automate Quay image push on tag and add digest usage guidance

## Why? 

* Effective usage of git tags. As Git tags is used to provide a clear, traceable, and meaningful reference to specific points in your project's history—typically used for marking releases or important milestones.
* We believe this is essential to understand the tags and their reference from git 



## How? 
* Add necessary Drone steps to push tags
* Also ensure all the steps that are dependent are running on event of tag


## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
