### PR TITLE
 HOTFIX: add drone dependency attribute so tagging image happens after building image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -129,6 +129,8 @@ steps:
     when:
       branch: master
       event: [tag]
+    depends_on:
+      - build_image
 
   - name: scan_node_packages
     pull: always


### PR DESCRIPTION
## What? 
 HOTFIX: add drone dependency attribute so tagging image happens after building image
## Why? 
- push_image_tag_to_quay step is happening before build_image step (which takes longer because it is dependent on the setup step completing first and fails because it can't find the image"
## How? 
- add depends_on: build image property to push_image_tag_to_quay step
## Testing?
tested on pushing to master
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds lamp green especially tests
- [ ] I will squash the commits before merging
