### PR TITLE
HOFF-1947 add Github Action for Scanning Filevault

### DIFF
--- a/.github/workflows/scan-for-evil-packages.yml
+++ b/.github/workflows/scan-for-evil-packages.yml
@@ -1,0 +1,16 @@
+name: Scan for Evil Packages
+
+on:
+  repository_dispatch:
+    types: [trigger-from-scanmaestro]
+  pull_request:
+    branches: [master]
+
+jobs:
+  scan:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Run Scan for Evil Packages
+        uses: UKHomeOffice/hof-maestro-scanner/.github/actions/scan-for-evil-packages@main
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/scan-for-evil-packages.yml
+++ b/.github/workflows/scan-for-evil-packages.yml
@@ -5,7 +5,6 @@ on:
     types: [trigger-from-scanmaestro]
   pull_request:
     branches: [master]
-
 jobs:
   scan:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## What?
Added GitHub actions to scan dependency packages for file-vault as per  [HOFF-1947](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-1947)
## Why? 
Relates to [HOFF-1898](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-1898) file-vault: Create Github Action for Scanning
## How? 
 add .github/workflows/scan-for-evil-packages.yml file
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds lamp green especially tests
- [ ] I will squash the commits before merging
