### PR TITLE
HOFF-2164: hardened FV upload process to be strict on MIME type validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The service uses the `config` package and reads the following environment variab
 | `AWS_EXPIRY_TIME` | No | `3600` | Presigned URL expiry in seconds |
 | `REQUEST_TIMEOUT` | No | `15000` ms effective fallback if unset or invalid | Timeout for ClamAV and retrieval HTTP requests |
 | `STORAGE_FILE_DESTINATION` | No | `uploads` | Temporary upload directory |
-| `FILE_EXTENSION_WHITELIST` | No | empty | Comma-separated list of allowed file extensions |
+| `FILE_EXTENSION_WHITELIST` | Yes | empty, which rejects uploads | Comma-separated list of allowed file extensions. Uploads are rejected when this is empty. The final filename extension must be allowlisted, and dangerous nested extensions such as `.php` are rejected even when the client supplies an allowed multipart MIME type. |
 | `MAX_FILE_SIZE` | No | none | Available config value for scan-size limits |
 | `ALLOW_GENERATE_LINK_ROUTE` | No | `no` | Enables `GET /file/generate-link/:id` |
 | `RETURN_ORIGINAL_SIGNED_URL` | No | `no` | Includes the raw S3 presigned URL in upload responses |

--- a/controllers/file.js
+++ b/controllers/file.js
@@ -46,6 +46,75 @@ const upload = multer({
   dest: config.get('fileDestination')
 });
 
+// Explicitly block harmful MIME types that we wouldn't ever expect to be uploaded, even if they are in the allowed list. This is a defense-in-depth measure.
+const blockedNestedExtensions = new Set([
+  'bat',
+  'bash',
+  'cgi',
+  'cmd',
+  'dll',
+  'exe',
+  'htm',
+  'html',
+  'js',
+  'mjs',
+  'phar',
+  'php',
+  'phtml',
+  'pl',
+  'ps1',
+  'py',
+  'rb',
+  'sh'
+]);
+
+/**
+ * Parses the configured extension whitelist into normalized extension names.
+ *
+ * @returns {Set<string>} Allowed extension names without leading dots.
+ */
+function getAllowedExtensions() {
+  const fileTypes = config.get('fileTypes');
+
+  if (typeof fileTypes !== 'string') {
+    return new Set();
+  }
+
+  return new Set(fileTypes.split(',')
+    .map((allowedExtension) => allowedExtension.trim().toLowerCase().replace(/^\.+/, ''))
+    .filter(Boolean));
+}
+
+/**
+ * Extracts extension-like suffixes from a client supplied filename.
+ *
+ * @param {string} filename Uploaded original filename.
+ * @returns {string[]} Normalized suffixes after the first filename segment.
+ */
+function getFilenameExtensions(filename) {
+  const filenameParts = path.basename(filename || '')
+    .toLowerCase()
+    .split('.')
+    .filter(Boolean);
+
+  if (filenameParts.length < 2) {
+    return [];
+  }
+
+  return filenameParts.slice(1);
+}
+
+/**
+ * Checks whether any non-final suffix is a dangerous executable/script extension.
+ *
+ * @param {string[]} extensions Filename suffixes.
+ * @returns {boolean} True when a nested blocked suffix is present.
+ */
+function hasBlockedNestedExtension(extensions) {
+  return extensions.slice(0, -1)
+    .some((extension) => blockedNestedExtensions.has(extension));
+}
+
 /**
  * Validates an uploaded file extension against the configured whitelist.
  *
@@ -55,27 +124,26 @@ const upload = multer({
  * @returns {void}
  */
 function checkExtension(req, res, next) {
-  const fileTypes = config.get('fileTypes');
-
-  if (fileTypes) {
-    const uploadedFileExtension = path.extname(req.file.originalname).replace('.', '').toLowerCase();
-    const fileAllowed = fileTypes.split(',')
-      .find((allowedExtension) => uploadedFileExtension === allowedExtension);
-    if (fileAllowed) {
-
-      debug('passed file extension check');
-      next();
-    } else {
-
-      debug('failed file extension check');
-      next({
-        code: 'FileExtensionNotAllowed'
-      });
-    }
-  } else {
+  if (!req.file) {
     debug('passed file extension check');
-    next();
+    return next();
   }
+
+  const allowedExtensions = getAllowedExtensions();
+  const uploadedFileExtensions = getFilenameExtensions(req.file.originalname);
+  const uploadedFileExtension = uploadedFileExtensions[uploadedFileExtensions.length - 1];
+  const fileAllowed = uploadedFileExtension && allowedExtensions.has(uploadedFileExtension)
+    && !hasBlockedNestedExtension(uploadedFileExtensions);
+
+  if (fileAllowed) {
+    debug('passed file extension check');
+    return next();
+  }
+
+  debug('failed file extension check');
+  return next({
+    code: 'FileExtensionNotAllowed'
+  });
 }
 
 /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - AWS_PASSWORD=aws-password
       - NODE_ENV=development
       - ALLOW_GENERATE_LINK_ROUTE=no
+      - FILE_EXTENSION_WHITELIST=gif,jpg,jpeg,png,pdf
     depends_on:
       clamav-rest:
         condition: service_healthy

--- a/test/file.js
+++ b/test/file.js
@@ -23,7 +23,7 @@ function parseFileVaultUrl(fileVaultUrl) {
 }
 
 async function uploadDocumentWithSignedUrl() {
-  process.env.NODE_CONFIG = '{"aws": {"password":"atest"}, "fileTypes": "", "returnOriginalSignedUrl": "yes"}';
+  process.env.NODE_CONFIG = '{"aws": {"password":"atest"}, "fileTypes": "gif", "returnOriginalSignedUrl": "yes"}';
 
   nock('http://localhost:8080').post('/scan').once().reply(200, 'Everything ok : true');
   nock('https://testbucket.s3.eu-west-1.amazonaws.com').put(/.*/).reply(200);
@@ -53,7 +53,7 @@ describe('/file', () => {
     delete process.env.DEBUG;
     delete process.env.AWS_PASSWORD;
     delete process.env.FILE_EXTENSION_WHITELIST;
-    process.env.NODE_CONFIG = '{"aws": {"password":"atest"}, "fileTypes": ""}';
+    process.env.NODE_CONFIG = '{"aws": {"password":"atest"}, "fileTypes": "gif"}';
   });
 
   afterEach(() => {
@@ -169,6 +169,9 @@ describe('/file', () => {
     describe('data', () => {
 
       it('returns an error when virus scanner unavailable', async () => {
+        const axiosMock = jest.fn().mockRejectedValue(new Error('scanner unavailable'));
+        jest.doMock('axios', () => axiosMock);
+
         await supertest(require('../app').app)
           .post('/file')
           .attach('document', 'test/fixtures/cat.gif')
@@ -206,7 +209,7 @@ describe('/file', () => {
         });
 
         it('passes configured fileSize to virus scanner request', async () => {
-          process.env.NODE_CONFIG = '{"aws": {"password":"atest"}, "fileTypes": "", "fileSize": "98765"}';
+          process.env.NODE_CONFIG = '{"aws": {"password":"atest"}, "fileTypes": "gif", "fileSize": "98765"}';
 
           const axiosMock = jest.fn().mockResolvedValue({ data: 'Everything ok : true' });
           jest.doMock('axios', () => axiosMock);
@@ -226,7 +229,7 @@ describe('/file', () => {
         });
 
         it('returns error when file exceeds fileSize in virus scanner request', async () => {
-          process.env.NODE_CONFIG = '{"aws": {"password":"atest"}, "fileTypes": "", "fileSize": "100"}';
+          process.env.NODE_CONFIG = '{"aws": {"password":"atest"}, "fileTypes": "gif", "fileSize": "100"}';
 
           const axiosMock = jest.fn().mockResolvedValue({ data: 'Everything ok : false' });
           jest.doMock('axios', () => axiosMock);
@@ -271,6 +274,64 @@ describe('/file', () => {
             .expect(400, {
               code: 'FileExtensionNotAllowed'
             });
+        });
+
+        it('returns an error and does not scan when file extension whitelist is empty', async () => {
+          process.env.NODE_CONFIG = '{"aws": {"password":"atest"}, "fileTypes": ""}';
+          const axiosMock = jest.fn();
+          jest.doMock('axios', () => axiosMock);
+
+          await supertest(require('../app').app)
+            .post('/file')
+            .attach('document', 'test/fixtures/cat.gif')
+            .expect(400, {
+              code: 'FileExtensionNotAllowed'
+            });
+
+          expect(axiosMock).not.toHaveBeenCalled();
+        });
+
+        it('returns an error and does not scan when double extension ends with a blocked file type', async () => {
+          process.env.NODE_CONFIG = '{"aws": {"password":"atest"}, "fileTypes": "gif,jpg,jpeg,png,pdf"}';
+          const axiosMock = jest.fn();
+          jest.doMock('axios', () => axiosMock);
+
+          await supertest(require('../app').app)
+            .post('/file')
+            .attach('document', 'test/fixtures/cat.gif', { filename: 'malicious.png.php' })
+            .expect(400, {
+              code: 'FileExtensionNotAllowed'
+            });
+
+          expect(axiosMock).not.toHaveBeenCalled();
+        });
+
+        it('returns an error and does not scan when double extension hides a blocked file type', async () => {
+          process.env.NODE_CONFIG = '{"aws": {"password":"atest"}, "fileTypes": "gif,jpg,jpeg,png,pdf"}';
+          const axiosMock = jest.fn();
+          jest.doMock('axios', () => axiosMock);
+
+          await supertest(require('../app').app)
+            .post('/file')
+            .attach('document', 'test/fixtures/cat.gif', { filename: 'malicious.php.png' })
+            .expect(400, {
+              code: 'FileExtensionNotAllowed'
+            });
+
+          expect(axiosMock).not.toHaveBeenCalled();
+        });
+
+        it('normalises whitespace and casing in file extension whitelist entries', async () => {
+          process.env.NODE_CONFIG = '{"aws": {"password":"atest"}, "fileTypes": " JPG, PDF , GiF "}';
+          nock('http://localhost:8080').post('/scan').once().reply(200, 'Everything ok : true');
+          nock('https://testbucket.s3.eu-west-1.amazonaws.com').put(/.*/).reply(200);
+
+          const res = await supertest(require('../app').app)
+            .post('/file')
+            .attach('document', 'test/fixtures/cat.gif')
+            .expect(200);
+
+          assert.ok(res.body.url.indexOf('http://localhost/file/') !== -1);
         });
 
         it('returns when uppercase file extension is used', async () => {
@@ -318,7 +379,7 @@ describe('/file', () => {
         });
 
         it('returns the original signed url when configured', async () => {
-          process.env.NODE_CONFIG = '{"aws": {"password":"atest"}, "fileTypes": "", "returnOriginalSignedUrl": "yes"}';
+          process.env.NODE_CONFIG = '{"aws": {"password":"atest"}, "fileTypes": "gif", "returnOriginalSignedUrl": "yes"}';
 
           nock('http://localhost:8080').post('/scan').once().reply(200, 'Everything ok : true');
           nock('https://testbucket.s3.eu-west-1.amazonaws.com').put(/.*/).reply(200);
@@ -461,7 +522,9 @@ describe('/file', () => {
         });
 
         it('uses the configured timeout when timeout config is valid', async () => {
-          process.env.NODE_CONFIG = '{"aws": {"password":"atest"}, "fileTypes": "", "timeout": "20"}';
+          process.env.NODE_CONFIG = '{"aws": {"password":"atest"}, "fileTypes": "gif", "timeout": "20"}';
+          const axiosMock = jest.fn().mockRejectedValue(new Error('scanner unavailable'));
+          jest.doMock('axios', () => axiosMock);
 
           await supertest(require('../app').app)
             .post('/file')
@@ -469,6 +532,10 @@ describe('/file', () => {
             .expect(400, {
               code: 'VirusScanFailed'
             });
+
+          expect(axiosMock).toHaveBeenCalledWith(expect.objectContaining({
+            timeout: 20000
+          }));
         });
       });
 


### PR DESCRIPTION
## What? 

This PR hardens the file-vault (FV) upload process by implementing strict MIME type validation to prevent any potential request manipulation leading to an invalid file being uploaded.

## Why? 

The recent ITHC uncovered the ability to intercept a request made to the FV service and change the MIME type of a file mid-flight. This bypassed the extension checking functionality and successfully lead to a potentially malicious file upload. This process can also easily be achieved by a simple curl to the file-vault instance (although this is near impossible in reality).

## How? 

* Added strict file extension checking, not just relying on the last MIME type
* Added strict checking on supplied FILE_EXTENSION_WHITELIST - if this isn't provided on service initialisation, FV will fail fast
* Added explicit list of dis-allowed files, regardless of if they're present in the allow list

## Testing?

- Unit tests added
- Burp suite intercept test performed
- Curl testing performed

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [X] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [X] I have written tests (if relevant)
- [X] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
-  [X] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [X] Ensure drone builds lamp green especially tests
- [ ] I will squash the commits before merging
